### PR TITLE
Drop `libgcc`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,8 @@ source:
     md5: d8f70abafd3e9f0bae03c52d1f4e8de5
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win]
-
-requirements:
-    run:
-        - libgcc
 
 test:
     commands:


### PR DESCRIPTION
`gcc` was dropped in PR ( https://github.com/conda-forge/gsl-feedstock/pull/2 ). However, `libgcc` seems to not have been removed as a run-time dependency. This removes it.