### PR TITLE
Quasi no-op PR to retrigger the Linux build [skip appveyor] [skip travis]

### DIFF
--- a/.ci_support/linux_c_compilergcc.yaml
+++ b/.ci_support/linux_c_compilergcc.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 openblas:
 - 0.3.3
 pin_run_as_build:


### PR DESCRIPTION
The latest PR didn't trigger a build on Linux. This PR barely changes anything but can hopefully fix that. Intentionally *not* bumping the build number; macOS and Windows packages should already be fine.