### PR TITLE
Ensure that on Windows the public symbols of the shared library can be used

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,10 @@
+set RECIPE_DIR_BACKUP=%RECIPE_DIR%
 call %BUILD_PREFIX%\Library\bin\run_autotools_clang_conda_build.bat
 if errorlevel 1 exit 1
+:: Restore RECIPE_DIR, workaround for https://github.com/conda-forge/autotools_clang_conda-feedstock/issues/13
+set RECIPE_DIR=%RECIPE_DIR_BACKUP%
 
+:: Ensure that the header on Windows is compatible out of the box 
+:: with shared library (see https://github.com/conda-forge/gsl-feedstock/issues/50)
+copy /y "%RECIPE_DIR%\windows_shared.gsl_types.h" "%LIBRARY_INC%\gsl\gsl_types.h"
+if errorlevel 1 exit 1

--- a/recipe/windows_shared.gsl_types.h
+++ b/recipe/windows_shared.gsl_types.h
@@ -1,0 +1,42 @@
+/* gsl_types.h
+ * 
+ * Copyright (C) 2001, 2007 Brian Gough
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or (at
+ * your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GSL_TYPES_H__
+#define __GSL_TYPES_H__
+
+#ifndef GSL_VAR
+
+#if 1 /*WIN32*/
+#  if 1 /*GSL_DLL*/
+#    ifdef DLL_EXPORT
+#      define GSL_VAR extern __declspec(dllexport)
+#    else
+#      define GSL_VAR extern __declspec(dllimport)
+#    endif
+#  else
+#    define GSL_VAR extern
+#  endif
+#else
+#  define GSL_VAR extern
+#endif
+
+#endif
+
+#endif /* __GSL_TYPES_H__ */
+


### PR DESCRIPTION
Fix https://github.com/conda-forge/gsl-feedstock/issues/50

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
