### PR TITLE
Add regression test for visibility and more path workarounds

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,15 @@
 set RECIPE_DIR_BACKUP=%RECIPE_DIR%
+set LIBRARY_INC_BACKUP=%LIBRARY_INC%
+set PREFIX_BACKUP=%PREFIX%
 call %BUILD_PREFIX%\Library\bin\run_autotools_clang_conda_build.bat
 if errorlevel 1 exit 1
-:: Restore RECIPE_DIR, workaround for https://github.com/conda-forge/autotools_clang_conda-feedstock/issues/13
+:: Restore RECIPE_DIR, LIBRARY_INC and PREFIX workaround
+:: for https://github.com/conda-forge/autotools_clang_conda-feedstock/issues/13
+set PREFIX=%PREFIX_BACKUP%
+set LIBRARY_INC=%LIBRARY_INC_BACKUP%
 set RECIPE_DIR=%RECIPE_DIR_BACKUP%
 
-:: Ensure that the header on Windows is compatible out of the box 
+:: Ensure that the header on Windows is compatible out of the box
 :: with shared library (see https://github.com/conda-forge/gsl-feedstock/issues/50)
 copy /y "%RECIPE_DIR%\windows_shared.gsl_types.h" "%LIBRARY_INC%\gsl\gsl_types.h"
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,3 +64,4 @@ extra:
     - kwilcox
     - mingwandroid
     - ocefpaf
+    - traversaro

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch_for_windows.diff  # [win]
 
 build:
-  number: 1
+  number: 2
   skip:  True  # [win and vc<14]
   run_exports:
     # tends to break at minor revs
@@ -33,6 +33,12 @@ requirements:
   run:
 
 test:
+  files:
+    - test
+
+  requires:
+    - {{ compiler('c') }}
+
   commands:
     - gsl-config --prefix  # [not win]
     - if not exist %LIBRARY_LIB%\\gsl.lib       exit 1   # [win]

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,15 @@
+setlocal EnableDelayedExpansion
+
+cd test
+
+:: Compile example that links gsl
+echo "%PREFIX%\Library\include\gsl\gsl_types.h header during test"
+type "%PREFIX%\Library\include\gsl\gsl_types.h"
+
+:: Compile example that links gsl
+cl.exe /I%PREFIX%\Library\include\gsl gsl.lib regression_test.c
+if errorlevel 1 exit 1
+
+:: Run test
+.\regression_test.exe
+if errorlevel 1 exit 1

--- a/recipe/test/regression_test.c
+++ b/recipe/test/regression_test.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <gsl_rng.h>
+#include <gsl_randist.h>
+
+int main(int argv, char* argc[])
+{
+  // Regression test for https://github.com/conda-forge/ipopt-feedstock/issues/57
+  gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
+  
+  if (r == NULL) 
+  {
+    return 1;
+  }
+  
+  gsl_rng_free(r);
+
+  return 0;
+}


### PR DESCRIPTION
Despite local inspection, something went wrong in https://github.com/conda-forge/gsl-feedstock/pull/53, and the archives uploaded still contain the old gsl_types.h header. To debug the problem and avoid further regressions in the future, I added a compilation test for this.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
